### PR TITLE
fix(profile): signer drill-down uses parent URL state

### DIFF
--- a/app/components/custom/app-detail-view.tsx
+++ b/app/components/custom/app-detail-view.tsx
@@ -2,20 +2,20 @@
 
 import { timeAgo } from '../../lib/signer-helpers';
 import type { AppWithSigners } from '../../lib/signer-helpers';
-import { useOptionalUrlQueryState } from '@/app/hooks/use-url-query-state';
 
 interface AppDetailViewProps {
   app: AppWithSigners;
   fid: string;
   onBack: () => void;
+  /** Parent `ProfileDetails` setter for the `signer` query param (single source of truth). */
+  onSignerSelect: (signerKey: string) => void;
   userProfile?: {
     username?: string;
     fid?: string;
   };
 }
 
-export function AppDetailView({ app, fid, onBack, userProfile }: AppDetailViewProps) {
-  const [selectedSignerKey, setSelectedSignerKey] = useOptionalUrlQueryState('signer');
+export function AppDetailView({ app, fid, onBack, onSignerSelect, userProfile }: AppDetailViewProps) {
 
   return (
     <div className="w-screen h-screen flex justify-center items-start">
@@ -62,7 +62,7 @@ export function AppDetailView({ app, fid, onBack, userProfile }: AppDetailViewPr
                 .map((signer, index) => (
                   <button
                     key={index}
-                    onClick={() => signer.messageStats && signer.messageStats.total > 0 ? setSelectedSignerKey(signer.key) : undefined}
+                    onClick={() => signer.messageStats && signer.messageStats.total > 0 ? onSignerSelect(signer.key) : undefined}
                     className={`border border-black p-2 text-left w-full ${signer.messageStats && signer.messageStats.total > 0 ? 'hover:bg-gray-50 cursor-pointer' : 'cursor-default'}`}
                   >
                     <div className="font-mono text-xs text-gray-500 break-all mb-2">

--- a/app/components/custom/profile-details/index.tsx
+++ b/app/components/custom/profile-details/index.tsx
@@ -49,7 +49,11 @@ export default function ProfileDetails({ fid, hypersnapUser, keysData }: { fid: 
       <AppDetailView 
         app={selectedApp} 
         fid={fid} 
-        onBack={() => setSelectedAppFid(null)}
+        onBack={() => {
+          setSelectedSignerKey(null);
+          setSelectedAppFid(null);
+        }}
+        onSignerSelect={setSelectedSignerKey}
         userProfile={{
           username: hypersnapUser.username,
           fid: hypersnapUser.fid.toString()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`AppDetailView` had its own `useOptionalUrlQueryState('signer')`, so clicking a signer updated the URL and a second hook instance while `ProfileDetails` never saw `selectedSignerKey`, so `SignerDetail` never mounted. Signer selection now goes through the parent setter (`onSignerSelect`).

## Test plan

- Manual: `/fids/616` → Signers tab → open an app → click a signer with messages → confirm **signer messages** view with filters and message grid.
- `bun run lint` and `bun run build` both pass on this branch.

## Demo

Screen recording of the flow on local dev (`bun run dev`):

https://github.com/user-attachments/assets/100e3730-d64a-46d5-add8-91bdc65e0ef0

<a href="https://cursor.com/agents/bc-dbfb04f0-966e-45cf-98d8-cc817fe72768/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsigner-drill-down-demo.mp4"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

------

<div><a href="https://cursor.com/agents/bc-dbfb04f0-966e-45cf-98d8-cc817fe72768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbfb04f0-966e-45cf-98d8-cc817fe72768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

